### PR TITLE
Add some process stages to the Architecture (add stages section)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,13 @@ related:
 * {{ "scaffold" | dfn }}
 * {{ "elevation" | dfn }}
 
+### Stages
+
+* {{ "rough in" | dfn }} or {{ "cut out" | dfn }}
+* {{ "fit out" | dfn }} or fit off
+* {{ "lockup" | dfn }}
+* {{ "handover" | dfn }}
+
 ## Parts
 
 * {{ "fitting" | dfn }}


### PR DESCRIPTION
Similar to https://github.com/paulrobertlloyd/classnames/pull/2 - some suggestions for mapping a development process to construction terms. 

Some of these do now show up in the definition search page though. I'm not sure if these should be directed to a custom URL instead. 