### PR TITLE
Remove 'GovUK' from meta title tag

### DIFF
--- a/lib/layouts/collection.njk
+++ b/lib/layouts/collection.njk
@@ -1,5 +1,9 @@
 {% extends "layouts/collection.njk" %}
 
+{% block pageTitle -%}
+  {% if pageName %}{{ pageName }} - {% endif %}{{ title }} - Classnames
+{%- endblock %}
+
 {% block head %}
   {{ super() }}
   {% include "_head.njk" %}

--- a/lib/layouts/sub-navigation.njk
+++ b/lib/layouts/sub-navigation.njk
@@ -1,5 +1,9 @@
 {% extends "layouts/sub-navigation.njk" %}
 
+{% block pageTitle -%}
+  {% if pageName %}{{ pageName }} - {% endif %}{{ title }} - Classnames
+{%- endblock %}
+
 {% block head %}
   {{ super() }}
   {% include "_head.njk" %}


### PR DESCRIPTION
Lovely little project this.

Can't find another way to do this via configuration because it's hardcoded in the parent templates ¯\_(ツ)_/¯